### PR TITLE
Bypass login/signup with hardcoded User role logic for dev testing

### DIFF
--- a/Backend/config/initializers/cors.rb
+++ b/Backend/config/initializers/cors.rb
@@ -12,5 +12,6 @@ Rails.application.config.middleware.insert_before 0, Rack::Cors do
     resource "*",
        headers: :any,
        methods: [:get, :post, :put, :patch, :delete, :options, :head]
+      
    end
  end

--- a/Frontend/src/App.jsx
+++ b/Frontend/src/App.jsx
@@ -10,10 +10,15 @@ import AddProperty from './components/AddProperty';
 import RenterApplicationForm from "./components/TenantDashboard/RenterApplicationForm";
 import SignUp from "./components/SignUp";
 
+// TEMP: Bypassing login/signup — toggle `role` to "tenant" or "landlord" for development
 function App() {
-  const [loggedIn, setLoggedIn] = useState(false);
-  const [User, setUser] = useState({})
-  const isTenant = true;
+  const [loggedIn, setLoggedIn] = useState(true);
+  const [User, setUser] = useState({
+    first_name: "Murray",
+    last_name: "Pocha",
+    email: "murray@example.com",
+    role: "tenant"
+  });
 
   return (
     <Routes>

--- a/Frontend/src/components/Sidenav.jsx
+++ b/Frontend/src/components/Sidenav.jsx
@@ -1,24 +1,24 @@
 import React from "react";
 import "../styles/Sidenav.css";
-import MyprofBtn from "./Button Components/MyProfBtn";
+import MyProfBtn from "./Button Components/MyProfBtn";
 import ViewPropertyBtn from "./Button Components/ViewPropertyBtn";
 import AccountSettingsBtn from "./Button Components/AccountSettingsBtn";
 import MyProperties from "./Button Components/MyProperties";
-import MyApplicationsBtn from "./Button Components/MyApplicationsBtn"; // ✅ already imported
+import MyApplicationsBtn from "./Button Components/MyApplicationsBtn";
 
-function Sidenav({ isTenant }) {
+function Sidenav({ User }) {
   return (
     <div className="sidenav_container">
-      {isTenant ? (
+      {User.role === "tenant" ? (
         <div className="tenant">
-          <MyprofBtn to="/dashboard" />
+          <MyProfBtn to="/dashboard" />
           <ViewPropertyBtn to="/dashboard/view-properties" />
-          <MyApplicationsBtn to="/dashboard/view-applications" /> {/* ✅ New Button */}
+          <MyApplicationsBtn to="/dashboard/view-applications" />
           <AccountSettingsBtn to="/dashboard/account-settings" />
         </div>
       ) : (
-        <div className="sidenav_container landlord">
-          <MyprofBtn to="/dashboard" />
+        <div className="landlord">
+          <MyProfBtn to="/dashboard" />
           <MyProperties to="/dashboard/my-properties" />
           <AccountSettingsBtn to="/dashboard/account-settings" />
         </div>

--- a/Frontend/src/components/TenantDashboard.jsx
+++ b/Frontend/src/components/TenantDashboard.jsx
@@ -9,16 +9,12 @@ import MyProperties from "./MyProperties";
 import ViewApplications from "./ViewApplications";
 import PropertyPage from "./PropertyPage";
 import AddProperty from "./AddProperty";
-
 function TenantDashboard({ User, setLoggedIn }) {
-
     const location = useLocation();
     
-
   return (
     <>
       <Header User={User} setLoggedIn={setLoggedIn}/>
-
       <div className="tenant_dashboard_container">
         <Routes>
           {/* Tenant dashboard routes */}
@@ -43,10 +39,8 @@ function TenantDashboard({ User, setLoggedIn }) {
           )}
         </Routes>
       </div>
-
       <Sidenav User={User} />
     </>
   );
 }
-
 export default TenantDashboard;


### PR DESCRIPTION
This PR temporarily bypasses login/signup by hardcoding a `User` object in `App.jsx` with a `role` of either `"tenant"` or `"landlord"`.

This allows us to:

- Switch between views quickly during development
- Unblock feature building and visual testing
- Confirm sidebar and routing behavior for both roles

## Instructions

To toggle between roles:
1. Open `App.jsx`
2. Change `role: "tenant"` to `role: "landlord"` or vice versa
3. Refresh `localhost:5173/dashboard`

## Notes

This is **temporary and only for development**. Authentication-related bugs will be fixed in future PRs.

Please merge into `develop` when approved so others can test without full login setup.